### PR TITLE
WIP: Allow users to control which groups a client is added to

### DIFF
--- a/graphene_subscriptions/events.py
+++ b/graphene_subscriptions/events.py
@@ -10,14 +10,15 @@ DELETED = "deleted"
 
 
 class SubscriptionEvent:
-    def __init__(self, operation=None, instance=None):
+    def __init__(self, operation=None, instance=None, group=None):
         self.operation = operation
         self.instance = instance
+        self.group = group if group is not None else "subscriptions"
 
     def send(self):
         channel_layer = get_channel_layer()
         async_to_sync(channel_layer.group_send)(
-            "subscriptions", {"type": "signal.fired", "event": self.to_dict()}
+            self.group, {"type": "signal.fired", "event": self.to_dict()}
         )
 
     def to_dict(self):
@@ -37,8 +38,8 @@ class SubscriptionEvent:
 
 
 class ModelSubscriptionEvent(SubscriptionEvent):
-    def __init__(self, operation=None, instance=None):
-        super(ModelSubscriptionEvent, self).__init__(operation, instance)
+    def __init__(self, operation=None, instance=None, group=None):
+        super(ModelSubscriptionEvent, self).__init__(operation, instance, group)
 
         if type(self.instance) == str:
             # deserialize django object

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -36,6 +36,14 @@ class SomeModelUpdatedSubscription(graphene.ObjectType):
         ).map(lambda event: event.instance)
 
 
+class SomeModelUpdatedCustomSubscription(graphene.ObjectType):
+    some_model_updated_custom = graphene.Field(SomeModelType, id=graphene.ID())
+
+    def resolve_some_model_updated_custom(root, info, id):
+        info.context.subscribe(f"modelUpdated.{id}")
+        return root.map(lambda event: event.instance)
+
+
 class SomeModelDeletedSubscription(graphene.ObjectType):
     some_model_deleted = graphene.Field(SomeModelType, id=graphene.ID())
 
@@ -60,6 +68,7 @@ class Subscription(
     CustomEventSubscription,
     SomeModelCreatedSubscription,
     SomeModelUpdatedSubscription,
+    SomeModelUpdatedCustomSubscription,
     SomeModelDeletedSubscription,
 ):
     hello = graphene.String()


### PR DESCRIPTION
This PR fixes #6 by allowing users to manually control which Channel Layers groups a subscribed client is added to, and which groups subscription events are broadcast over.

A new function called `subscribe` will be passed to each Subscription resolver in the `info.context` dict. When called, this function will add the currently connected client to the specified group.

`SubscriptionEvent` and `ModelSubscriptionEvent` both now take an additional `group` parameter, which determines which group the event will be broadcast over.

Making use of this feature will require users to define their own signal handlers and manually trigger subscription events.

Example:
```python
# your_app/graphql/subscriptions.py
class MessageCreatedSubscription(graphene.ObjectType):
    message_created = graphene.Field(MessageType, room=graphene.ID())

    def resolve_message_created(root, info, room):
        info.context.subscribe(f"messageCreated.{room}")
        return root.map(lambda event: event.instance)

# your_app/signals.py
from django.db.models.signals import post_save
from graphene_subscriptions.events import ModelSubscriptionEvent, CREATED

def on_message_created(sender, instance, created, **kwargs):
    if created:
        event = ModelSubscriptionEvent(
            operation=CREATED,
            instance=instance,
            group=f"modelCreated.{instance.room.id}"
        )
        event.send()
        
post_save.connect(on_message_created, sender=Message, dispatch_uid="message_created")
```