### PR TITLE
Handle connection_init and connection_terminate

### DIFF
--- a/graphene_subscriptions/consumers.py
+++ b/graphene_subscriptions/consumers.py
@@ -49,7 +49,10 @@ class GraphqlSubscriptionConsumer(SyncConsumer):
         id = request.get("id")
 
         if request["type"] == "connection_init":
-            return
+            self.send({"type": "connection_ack"})
+
+        elif request["type"] == "connection_terminate":
+            self.websocket_disconnect(message)
 
         elif request["type"] == "start":
             payload = request["payload"]

--- a/graphene_subscriptions/consumers.py
+++ b/graphene_subscriptions/consumers.py
@@ -49,7 +49,7 @@ class GraphqlSubscriptionConsumer(SyncConsumer):
         id = request.get("id")
 
         if request["type"] == "connection_init":
-            self.send({"type": "connection_ack"})
+            self._send_connection_ack()
 
         elif request["type"] == "connection_terminate":
             self.websocket_disconnect(message)
@@ -94,6 +94,18 @@ class GraphqlSubscriptionConsumer(SyncConsumer):
                             "data": result.data,
                             "errors": list(map(str, errors)) if errors else None,
                         },
+                    }
+                ),
+            }
+        )
+
+    def _send_connection_ack(self):
+        self.send(
+            {
+                "type": "websocket.send",
+                "text": json.dumps(
+                    {
+                        "type": "connection_ack",
                     }
                 ),
             }

--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -1,0 +1,31 @@
+import pytest
+from channels.testing import WebsocketCommunicator
+
+from graphene_subscriptions.consumers import GraphqlSubscriptionConsumer
+
+
+@pytest.mark.asyncio
+async def test_consumer_connection_init():
+    communicator = WebsocketCommunicator(GraphqlSubscriptionConsumer, "/graphql/")
+    connected, subprotocol = await communicator.connect()
+    assert connected
+
+    await communicator.send_json_to({"type": "connection_init"})
+
+    response = await communicator.receive_json_from()
+
+    assert response["type"] == "connection_ack"
+
+
+@pytest.mark.asyncio
+async def test_consumer_connection_terminate():
+    communicator = WebsocketCommunicator(GraphqlSubscriptionConsumer, "/graphql/")
+    connected, subprotocol = await communicator.connect()
+    assert connected
+
+    await communicator.send_json_to({"type": "connection_terminate"})
+
+    response = await communicator.receive_output()
+
+    assert response["type"] == "websocket.close"
+    assert response["code"] == 1000


### PR DESCRIPTION
When using Apollo Client (specifically `subscriptions-transport-ws`) the [websocket client expects](https://github.com/apollographql/subscriptions-transport-ws/blob/567fca89cb4578371877faee09e1630dcddff544/src/client.ts#L614) either a `connection_ack` or `connection_error` response from the server after sending the initial `connection_init` message.

Currently, `graphene-subscriptions` just ignores these message types which causes the client to never emit `connected` events and may cause a `maxConnectTime` trigger to be performed.