### PR TITLE
Created an API to easily define django model connections

### DIFF
--- a/graphene_subscriptions/subscriptions.py
+++ b/graphene_subscriptions/subscriptions.py
@@ -49,13 +49,6 @@ class DjangoObjectSubscription(ObjectType):
             ), f'All interfaces of {cls.__name__} must be a subclass of Interface. Received "{interface}".'
             fields.update(interface._meta.fields)
 
-        if not output:
-            # If output is defined, we don't need to get the fields
-            fields = {}
-            for base in reversed(cls.__mro__):
-                fields.update(yank_fields_from_attrs(base.__dict__, _as=Field))
-            output = cls
-
         if not arguments:
             input_class = getattr(cls, "Arguments", None)
             if input_class:

--- a/graphene_subscriptions/subscriptions.py
+++ b/graphene_subscriptions/subscriptions.py
@@ -1,0 +1,123 @@
+from django.db import models
+from django.db.models.signals import post_save, post_delete
+from graphene import ObjectType, Field
+from graphene.types.objecttype import ObjectTypeOptions
+from graphene.types import Interface
+from graphene.types.utils import yank_fields_from_attrs
+from .events import ModelSubscriptionEvent, CREATED, UPDATED, DELETED
+from graphene.utils.props import props
+
+class SubscriptionOptions(ObjectTypeOptions):
+    model = None
+    name = None
+    description = None
+    arguments = None
+    output = None
+    resolver = None
+    interfaces = ()
+
+class DjangoObjectSubscription(ObjectType):
+    @classmethod
+    def __init_subclass_with_meta__(
+        cls,
+        model=None,
+        name=None,
+        description=None,
+        interfaces=(),
+        resolver=None,
+        output=None,
+        _meta=None,
+        arguments=None,
+        **options
+    ):
+
+        assert model, "All Objects must define a Meta class with the model in it"
+        assert issubclass(model, models.Model), "Model value must be a valid Django model"
+
+        assert output, "Output Type must be defined in the Meta class"
+        assert issubclass(output, ObjectType), "Outout Type must be a valid graphene object type"
+        
+        if not _meta:
+            _meta = SubscriptionOptions(cls)
+
+        output = output or getattr(cls, "Output", None)
+        fields = {}
+
+        for interface in interfaces:
+            assert issubclass(
+                interface, Interface
+            ), f'All interfaces of {cls.__name__} must be a subclass of Interface. Received "{interface}".'
+            fields.update(interface._meta.fields)
+
+        if not output:
+            # If output is defined, we don't need to get the fields
+            fields = {}
+            for base in reversed(cls.__mro__):
+                fields.update(yank_fields_from_attrs(base.__dict__, _as=Field))
+            output = cls
+
+        if not arguments:
+            input_class = getattr(cls, "Arguments", None)
+            if input_class:
+                arguments = props(input_class)
+            else:
+                arguments = {}
+
+        if not resolver:
+            resolver = cls._resolver
+
+        assert hasattr(cls, "subscribe"), "All subscribtions must define a subscribe method in it"
+
+        post_save.connect(ModelSubscriptionObjectType.post_save_subscription, sender=model)
+        post_delete.connect(ModelSubscriptionObjectType.post_delete_subscription, sender=model)
+
+        if _meta.fields:
+            _meta.fields.update(fields)
+        else:
+            _meta.fields = fields
+
+        _meta.interfaces = interfaces
+        _meta.output = output
+        _meta.resolver = resolver
+        _meta.arguments = arguments
+        _meta.name = name
+        _meta.model = model
+        _meta.description = description
+
+        super(ModelSubscriptionObjectType, cls).__init_subclass_with_meta__(_meta=_meta, name=name, description=description, **options)
+        
+
+    @staticmethod
+    def post_save_subscription(sender, instance, created, *args, **kwargs):
+        event = ModelSubscriptionEvent(
+            operation=CREATED if created else UPDATED, instance=instance
+        )
+        event.send()
+
+    @staticmethod
+    def post_delete_subscription(sender, instance, *args, **kwargs):
+        event = ModelSubscriptionEvent(operation=DELETED, instance=instance)
+        event.send()
+
+    @classmethod
+    def resolve(cls, root, info, event, *args, **kwargs):
+        try:
+            return cls.subscribe(root, info, event.operation, event.instance, *args, **kwargs)
+        except AttributeError:
+            return cls.subscribe(root, info, *args, **kwargs)
+
+    @classmethod
+    def _resolver(cls, root, info, *args, **kwargs):
+        return root.map(lambda event: cls.resolve(root, info, event, *args, **kwargs))
+
+    @classmethod
+    def Field(cls, name=None, description=None, deprecation_reason=None, required=False):
+        return Field(
+            cls._meta.output, 
+            args=cls._meta.arguments,
+            resolver=cls._meta.resolver,
+            name=name,
+            description=description or cls._meta.description,
+            deprecation_reason=deprecation_reason,
+            required=required,
+        )

--- a/graphene_subscriptions/subscriptions.py
+++ b/graphene_subscriptions/subscriptions.py
@@ -68,8 +68,8 @@ class DjangoObjectSubscription(ObjectType):
 
         assert hasattr(cls, "subscribe"), "All subscribtions must define a subscribe method in it"
 
-        post_save.connect(ModelSubscriptionObjectType.post_save_subscription, sender=model)
-        post_delete.connect(ModelSubscriptionObjectType.post_delete_subscription, sender=model)
+        post_save.connect(DjangoObjectSubscription.post_save_subscription, sender=model)
+        post_delete.connect(DjangoObjectSubscription.post_delete_subscription, sender=model)
 
         if _meta.fields:
             _meta.fields.update(fields)
@@ -84,7 +84,7 @@ class DjangoObjectSubscription(ObjectType):
         _meta.model = model
         _meta.description = description
 
-        super(ModelSubscriptionObjectType, cls).__init_subclass_with_meta__(_meta=_meta, name=name, description=description, **options)
+        super(DjangoObjectSubscription, cls).__init_subclass_with_meta__(_meta=_meta, name=name, description=description, **options)
         
 
     @staticmethod


### PR DESCRIPTION
Created a simple API to easily define subscriptions related to django models.

Using the `DjangoObjectSubscription`, you can define the subscribtion like below:
```python
from graphene_subscriptions.subscriptions import DjangoObjectSubscription

class YourModelSubscription(DjangoObjectSubscription):
  class Meta:
    model = YourModel
    output = YourModelType # the type of the subscription - can be a DjangoObjectType or a regular Graphene Type

  class Arguments:
    # define arguments

  def subsribe(root, info, operation, instance, *args, **kwargs):
    if operation == "created":
      # do something

    return something # something would be an object which would have the attributes of the output type.

class Subscriptions(graphene.ObjectType):
  your_model_subscription = YourModelSubscription.Field()
```

Why use this?
1. Don't have to manually connect your model to Django signals, it is automatically done under the hood. This really makes the library Plug-and-Play!
2. Wouldn't have to learn even the basics of the rxPy library to perform basic functions.
3. When you define Subscriptions using `DjangoObjectSubscription`, the structure of it is very similar to defining mutations using `graphene.Mutation`.
4. Code becomes much cleaner.

Some things that could be added:
1. Provide only a `DjangoObjectType` in the `Meta` subclass instead of the model and output type. (Adding this as optional would probably be better)
2. Let users define `on_save`, `on_update`, `on_delete`, functions separately which are run when a record from the model is created, updated and deleted respectively. (Again optional)

Let me know if it would be beneficial to add either of the features.

Also, would it be better to pass the operation and instance under a single argument `event` which can then be accessed from `event.operation` and `event.instance`?

I guess this would resolve #11 